### PR TITLE
Added output filtering by package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.3.0] - 2021-11-07
+
+- Added support for output filtering. 
+
 ## [0.2.0] - 2021-09-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Poetry export plugin
 
-This package is a plugin that allows the export of locked packages to various formats.
-
-**Note**: For now, only the `requirements.txt` format is available.
-
-This plugin provides the same features as the existing `export` command of Poetry which it will eventually replace.
-
+This package is a fork of [poetry/poetry-export-plugin](https://github.com/tailify/poetry-export-plugin) plugin
+that allows the export of locked packages with packages matching a regexp excluded from the output. The functionality
+frequently required to build Docker images or in monorepo builds.
 
 ## Installation
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -47,6 +47,14 @@ the `--without` option.
 poetry export --without test,docs
 ```
 
+Also, you can exclude packages from the export with one or more `--without-package`
+option providing a regular expression matching package names to exclude.
+
+```bash
+poetry export --without-package 'foo-.*' \
+              --without-packge 'bar-.*'
+```
+
 You can also select optional dependency groups with the `--with` option.
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-export-plugin"
-version = "0.2.0"
+version = "0.3.0"
 description = "Poetry plugin to export the dependencies to various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"

--- a/src/poetry_export_plugin/console/commands/export.py
+++ b/src/poetry_export_plugin/console/commands/export.py
@@ -41,6 +41,13 @@ class ExportCommand(Command):
             multiple=True,
         ),
         option(
+            "without-package",
+            None,
+            "The regexp matching package names to exclude",
+            flag=False,
+            multiple=True,
+        ),
+        option(
             "dev",
             None,
             "Include development dependencies. (<warning>Deprecated</warning>)",
@@ -63,6 +70,7 @@ class ExportCommand(Command):
             raise ValueError("Invalid export format: {}".format(fmt))
 
         excluded_groups = []
+        excluded_package_regexps = []
         included_groups = []
         only_groups = []
         if self.option("dev"):
@@ -98,6 +106,13 @@ class ExportCommand(Command):
         if self.option("default"):
             only_groups.append("default")
 
+        excluded_package_regexps.extend(
+            [
+                regexp.strip()
+                for regexp in self.option("without-package")
+            ]
+        )
+
         output = self.option("output")
 
         locker = self.poetry.locker
@@ -130,4 +145,5 @@ class ExportCommand(Command):
         exporter.with_extras(self.option("extras"))
         exporter.with_hashes(not self.option("without-hashes"))
         exporter.with_credentials(self.option("with-credentials"))
+        exporter.without_packages(excluded_package_regexps)
         exporter.export(fmt, self.poetry.file.parent, output or self.io)

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1641,3 +1641,51 @@ foo==1.2.3
 """
 
     assert out == expected
+
+
+def test_exporter_exports_requirements_txt_without_packages(tmp_dir, poetry, capsys):
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo-asdb",
+                    "version": "1.2.3",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                },
+                {
+                    "name": "foo-qwerty",
+                    "version": "1.2.4",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                },
+                {
+                    "name": "bar",
+                    "version": "4.5.6",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo-asdb": [], "foo-qwerty": [], "bar": []},
+            },
+        }
+    )
+    set_package_requires(poetry)
+
+    exporter = Exporter(poetry)
+    exporter.without_packages(['foo-.*'])
+
+    exporter.export("requirements.txt", Path(tmp_dir), sys.stdout)
+
+    out, err = capsys.readouterr()
+    expected = """\
+bar==4.5.6
+"""
+
+    assert out == expected


### PR DESCRIPTION
The change provides a way to filter output to requirements.txt format by the package name.

This is frequently required when poetry is used to build Docker images.