### PR TITLE
Release 1.0.1 (regression fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.0.1] - 2022-04-11
+
+### Fixed
+
+- Fixed a regression where export incorrectly always exported default group only. [#50](https://github.com/python-poetry/poetry-plugin-export/pull/50)
+
 ## [1.0.0] - 2022-04-05
 
 ### Fixed
@@ -31,7 +37,8 @@
 - Added support for dependency groups. [#6](https://github.com/python-poetry/poetry-plugin-export/pull/6)
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.0.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.0.1...main
+[1.0.1]: https://github.com/python-poetry/poetry-plugin-export/compare/1.0.1
 [1.0.0]: https://github.com/python-poetry/poetry-plugin-export/compare/1.0.0
 [0.2.1]: https://github.com/python-poetry/poetry-plugin-export/compare/0.2.1
 [0.2.0]: https://github.com/python-poetry/poetry-plugin-export/compare/0.2.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -642,7 +642,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "47488c6d0154828f63ebf2f95d6be02314fbd3e3e060fdbfd0b1bf526b8cfb84"
+content-hash = "90f3e97cd2d184279fb3e5c0ebf6cba349fbf615158e98817e27ad1925e895a2"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-export"
-version = "1.0.0"
+version = "1.0.1"
 description = "Poetry plugin to export the dependencies to various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"


### PR DESCRIPTION
### Fixed

- Fixed a regression where export incorrectly always exported default group only. [#50](https://github.com/python-poetry/poetry-plugin-export/pull/50)
