### PR TITLE
Rename implicit group "default" to "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ poetry export -f requirements.txt --output requirements.txt
 * `--without`: The dependency groups to ignore when exporting.
 * `--with`: The optional dependency groups to include when exporting.
 * `--only`: The only dependency groups to include when exporting.
-* `--default`: Only export the default dependencies.
+* `--default`: Only export the main dependencies. (**Deprecated**)
 * `--dev`: Include development dependencies. (**Deprecated**)
 * `--extras (-E)`: Extra sets of dependencies to include.
 * `--without-hashes`: Exclude hashes from the exported file.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -70,7 +70,7 @@ poetry export --only test,docs
 * `--without`: The dependency groups to ignore when exporting.
 * `--with`: The optional dependency groups to include when exporting.
 * `--only`: The only dependency groups to include when exporting.
-* `--default`: Only export the default dependencies.
+* `--default`: Only export the main dependencies. (**Deprecated**)
 * {{< option name="dev" deprecated=true >}}Include development dependencies.{{< /option >}}
 * `--extras (-E)`: Extra sets of dependencies to include.
 * `--without-hashes`: Exclude hashes from the exported file.

--- a/poetry.lock
+++ b/poetry.lock
@@ -373,7 +373,7 @@ virtualenv = "(>=20.4.3,<20.4.5 || >=20.4.7)"
 type = "git"
 url = "https://github.com/abn/poetry.git"
 reference = "use-export-plugin"
-resolved_reference = "642775bf9c7ad2ac74e9495fd8290525bb9060c9"
+resolved_reference = "2444521855c6f4c19a061d1f65c48fbc7d115fe5"
 
 [[package]]
 name = "poetry-core"

--- a/src/poetry_plugin_export/command.py
+++ b/src/poetry_plugin_export/command.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from cleo.helpers import option
 from poetry.console.commands.installer_command import InstallerCommand
 
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 from poetry_plugin_export.exporter import Exporter
 
 
@@ -43,7 +49,12 @@ class ExportCommand(InstallerCommand):
 
     @property
     def non_optional_groups(self) -> set[str]:
-        return {"default"}
+        # method only required for poetry <= 1.2.0-beta.2.dev0
+        return {MAIN_GROUP}
+
+    @property
+    def default_groups(self) -> set[str]:
+        return {MAIN_GROUP}
 
     def handle(self) -> None:
         fmt = self.option("format")

--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -8,6 +8,12 @@ from typing import Iterable
 from cleo.io.io import IO
 
 
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -30,7 +36,7 @@ class Exporter:
         self._with_credentials = False
         self._with_urls = True
         self._extras: list[str] = []
-        self._groups: Iterable[str] = ["default"]
+        self._groups: Iterable[str] = [MAIN_GROUP]
 
     @classmethod
     def is_format_supported(cls, fmt: str) -> bool:

--- a/tests/command/test_command_export.py
+++ b/tests/command/test_command_export.py
@@ -7,6 +7,12 @@ import pytest
 
 from poetry.core.packages.package import Package
 
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 from poetry_plugin_export.exporter import Exporter
 from tests.markers import MARKER_PY
 
@@ -152,13 +158,16 @@ foo==1.0.0 ; {MARKER_PY}
             f"baz==2.0.0 ; {MARKER_PY}\nfoo==1.0.0 ; {MARKER_PY}\nopt==2.2.0 ;"
             f" {MARKER_PY}\n",
         ),
-        ("--without default", "\n"),
+        (f"--without {MAIN_GROUP}", "\n"),
         ("--without dev", f"foo==1.0.0 ; {MARKER_PY}\n"),
         ("--without opt", f"foo==1.0.0 ; {MARKER_PY}\n"),
-        ("--without default,dev,opt", "\n"),
-        ("--only default", f"foo==1.0.0 ; {MARKER_PY}\n"),
+        (f"--without {MAIN_GROUP},dev,opt", "\n"),
+        (f"--only {MAIN_GROUP}", f"foo==1.0.0 ; {MARKER_PY}\n"),
         ("--only dev", f"baz==2.0.0 ; {MARKER_PY}\n"),
-        ("--only default,dev", f"baz==2.0.0 ; {MARKER_PY}\nfoo==1.0.0 ; {MARKER_PY}\n"),
+        (
+            f"--only {MAIN_GROUP},dev",
+            f"baz==2.0.0 ; {MARKER_PY}\nfoo==1.0.0 ; {MARKER_PY}\n",
+        ),
     ],
 )
 def test_export_groups(

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -15,6 +15,12 @@ from poetry.factory import Factory
 from poetry.packages import Locker as BaseLocker
 from poetry.repositories.legacy_repository import LegacyRepository
 
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 from poetry_plugin_export.exporter import Exporter
 from tests.markers import MARKER_PY
 from tests.markers import MARKER_PY27
@@ -540,7 +546,7 @@ def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers_a
 
     exporter = Exporter(poetry)
     if dev:
-        exporter.only_groups(["default", "dev"])
+        exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
 
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
@@ -715,7 +721,7 @@ def test_exporter_exports_requirements_txt_with_dev_packages_if_opted_in(
     set_package_requires(poetry)
 
     exporter = Exporter(poetry)
-    exporter.only_groups(["default", "dev"])
+    exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
 
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
@@ -802,7 +808,7 @@ def test_exporter_exports_requirements_txt_without_optional_packages(
     set_package_requires(poetry)
 
     exporter = Exporter(poetry)
-    exporter.only_groups(["default", "dev"])
+    exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
 
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
@@ -888,7 +894,7 @@ def test_exporter_exports_requirements_txt_with_optional_packages(
     set_package_requires(poetry)
 
     exporter = Exporter(poetry)
-    exporter.only_groups(["default", "dev"])
+    exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.with_hashes(False)
     exporter.with_extras(extras)
     exporter.export(
@@ -1457,7 +1463,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages(
     set_package_requires(poetry)
 
     exporter = Exporter(poetry)
-    exporter.only_groups(["default", "dev"])
+    exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
 
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
@@ -1515,7 +1521,7 @@ def test_exporter_exports_requirements_txt_with_url_false(tmp_dir: str, poetry: 
     set_package_requires(poetry)
 
     exporter = Exporter(poetry)
-    exporter.only_groups(["default", "dev"])
+    exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.with_urls(False)
     exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
 
@@ -1566,7 +1572,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages_trusted_host(
     )
     set_package_requires(poetry)
     exporter = Exporter(poetry)
-    exporter.only_groups(["default", "dev"])
+    exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
 
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
@@ -1650,7 +1656,7 @@ def test_exporter_exports_requirements_txt_with_dev_extras(
 
     exporter = Exporter(poetry)
     if dev:
-        exporter.only_groups(["default", "dev"])
+        exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
 
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
@@ -1724,7 +1730,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages_and_duplicate_so
     set_package_requires(poetry)
 
     exporter = Exporter(poetry)
-    exporter.only_groups(["default", "dev"])
+    exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
 
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
@@ -1790,7 +1796,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages_and_credentials(
     set_package_requires(poetry)
 
     exporter = Exporter(poetry)
-    exporter.only_groups(["default", "dev"])
+    exporter.only_groups([MAIN_GROUP, "dev"])
     exporter.with_credentials()
     exporter.export(
         "requirements.txt",
@@ -1956,7 +1962,7 @@ def test_exporter_doesnt_confuse_repeated_packages(tmp_dir: str, poetry: Poetry)
     poetry._package = root
 
     exporter = Exporter(poetry)
-    exporter.only_groups(["default", "dev"])
+    exporter.only_groups([MAIN_GROUP, "dev"])
     io = BufferedIO()
     exporter.export("requirements.txt", Path(tmp_dir), io)
 


### PR DESCRIPTION
This is done in order to avoid ambiguity between "default group" and "default dependencies" (the groups that are considered by a command by default)

Has to be considered together with python-poetry/poetry-core#326 and python-poetry/poetry#5465