### PR TITLE
tests: Remove bogus type parameter for Protocol

### DIFF
--- a/tests/types.py
+++ b/tests/types.py
@@ -3,19 +3,18 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Protocol
 
-from cleo.testers.command_tester import CommandTester
-
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from cleo.testers.command_tester import CommandTester
     from poetry.installation import Installer
     from poetry.installation.executor import Executor
     from poetry.poetry import Poetry
     from poetry.utils.env import Env
 
 
-class CommandTesterFactory(Protocol[CommandTester]):
+class CommandTesterFactory(Protocol):
     def __call__(
         self: CommandTester,
         command: str,


### PR DESCRIPTION
The tests are not currently type checked ([`files = "src"`](https://github.com/python-poetry/poetry-plugin-export/blob/5795ceedaa227b0e51fd8c61a19e4f9453747da5/pyproject.toml#L48)) and have many mypy errors yet to be addressed. But this didn’t even work at _runtime_, because `CommandTester` is a class, not a type variable.

```pytb
$ poetry run python -m tests.types
Traceback (most recent call last):
  File "…/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "…/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/anders/python/poetry-plugin-export/tests/types.py", line 18, in <module>
    class CommandTesterFactory(Protocol[CommandTester]):
  File "…/lib/python3.9/typing.py", line 277, in inner
    return func(*args, **kwds)
  File "…/lib/python3.9/typing.py", line 997, in __class_getitem__
    raise TypeError(
TypeError: Parameters to Protocol[...] must all be type variables
```