### PR TITLE
mypy: unignore `poetry` and `poetry.core`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -144,6 +144,25 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "dulwich"
+version = "0.20.40"
+description = "Python Git Library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.24.1"
+
+[package.extras]
+fastimport = ["fastimport"]
+https = ["urllib3[secure] (>=1.24.1)"]
+paramiko = ["paramiko"]
+pgp = ["gpg"]
+watch = ["pyinotify"]
+
+[[package]]
 name = "entrypoints"
 version = "0.3"
 description = "Discover and load entry points from installed packages."
@@ -308,14 +327,14 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "20.9"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pexpect"
@@ -380,15 +399,17 @@ cachecontrol = {version = "^0.12.9", extras = ["filecache"]}
 cachy = "^0.3.0"
 cleo = "^1.0.0a4"
 crashtest = "^0.3.0"
+dulwich = "^0.20.35"
 entrypoints = "^0.3"
 html5lib = "^1.0"
 importlib-metadata = {version = ">=1.6.0", markers = "python_version < \"3.8\""}
 keyring = ">=21.2.0"
-packaging = "^20.4"
+packaging = ">=20.4"
 pexpect = "^4.7.0"
 pkginfo = "^1.5"
-poetry-core = "^1.1.0a7"
-poetry-plugin-export = "^1.0"
+platformdirs = "^2.5.2"
+poetry-core = "^1.1.0b1"
+poetry-plugin-export = "^1.0.3"
 requests = "^2.18"
 requests-toolbelt = "^0.9.1"
 shellingham = "^1.1"
@@ -398,9 +419,9 @@ virtualenv = "(>=20.4.3,<20.4.5 || >=20.4.7)"
 
 [package.source]
 type = "git"
-url = "https://github.com/abn/poetry.git"
-reference = "use-export-plugin"
-resolved_reference = "2444521855c6f4c19a061d1f65c48fbc7d115fe5"
+url = "https://github.com/python-poetry/poetry.git"
+reference = "master"
+resolved_reference = "34c6da4c2cbdfd5572fc4711d3ee628bf80eba72"
 
 [[package]]
 name = "poetry-core"
@@ -608,7 +629,7 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "typed-ast"
-version = "1.5.3"
+version = "1.5.4"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
 optional = false
@@ -677,7 +698,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "47488c6d0154828f63ebf2f95d6be02314fbd3e3e060fdbfd0b1bf526b8cfb84"
+content-hash = "f0af589d1d01f52262c9c7dcfe276c7b9600210be11f756fa46dec9324a5988e"
 
 [metadata.files]
 atomicwrites = [
@@ -800,6 +821,9 @@ distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
+dulwich = [
+    {file = "dulwich-0.20.40.tar.gz", hash = "sha256:bed70efe0b7dd51a47bcea9b984ab06a675d7438b78b32da1cbafcf750fbbad7"},
+]
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
@@ -910,8 +934,8 @@ nodeenv = [
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
 packaging = [
-    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
-    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
@@ -1038,30 +1062,30 @@ tomlkit = [
     {file = "tomlkit-0.10.2.tar.gz", hash = "sha256:30d54c0b914e595f3d10a87888599eab5321a2a69abc773bbefff51599b72db6"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ad3b48cf2b487be140072fb86feff36801487d4abb7382bb1929aaac80638ea"},
-    {file = "typed_ast-1.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:542cd732351ba8235f20faa0fc7398946fe1a57f2cdb289e5497e1e7f48cfedb"},
-    {file = "typed_ast-1.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc2c11ae59003d4a26dda637222d9ae924387f96acae9492df663843aefad55"},
-    {file = "typed_ast-1.5.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fd5df1313915dbd70eaaa88c19030b441742e8b05e6103c631c83b75e0435ccc"},
-    {file = "typed_ast-1.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:e34f9b9e61333ecb0f7d79c21c28aa5cd63bec15cb7e1310d7d3da6ce886bc9b"},
-    {file = "typed_ast-1.5.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f818c5b81966d4728fec14caa338e30a70dfc3da577984d38f97816c4b3071ec"},
-    {file = "typed_ast-1.5.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3042bfc9ca118712c9809201f55355479cfcdc17449f9f8db5e744e9625c6805"},
-    {file = "typed_ast-1.5.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4fff9fdcce59dc61ec1b317bdb319f8f4e6b69ebbe61193ae0a60c5f9333dc49"},
-    {file = "typed_ast-1.5.3-cp36-cp36m-win_amd64.whl", hash = "sha256:8e0b8528838ffd426fea8d18bde4c73bcb4167218998cc8b9ee0a0f2bfe678a6"},
-    {file = "typed_ast-1.5.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ef1d96ad05a291f5c36895d86d1375c0ee70595b90f6bb5f5fdbee749b146db"},
-    {file = "typed_ast-1.5.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed44e81517364cb5ba367e4f68fca01fba42a7a4690d40c07886586ac267d9b9"},
-    {file = "typed_ast-1.5.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f60d9de0d087454c91b3999a296d0c4558c1666771e3460621875021bf899af9"},
-    {file = "typed_ast-1.5.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9e237e74fd321a55c90eee9bc5d44be976979ad38a29bbd734148295c1ce7617"},
-    {file = "typed_ast-1.5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ee852185964744987609b40aee1d2eb81502ae63ee8eef614558f96a56c1902d"},
-    {file = "typed_ast-1.5.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:27e46cdd01d6c3a0dd8f728b6a938a6751f7bd324817501c15fb056307f918c6"},
-    {file = "typed_ast-1.5.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d64dabc6336ddc10373922a146fa2256043b3b43e61f28961caec2a5207c56d5"},
-    {file = "typed_ast-1.5.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8cdf91b0c466a6c43f36c1964772918a2c04cfa83df8001ff32a89e357f8eb06"},
-    {file = "typed_ast-1.5.3-cp38-cp38-win_amd64.whl", hash = "sha256:9cc9e1457e1feb06b075c8ef8aeb046a28ec351b1958b42c7c31c989c841403a"},
-    {file = "typed_ast-1.5.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e20d196815eeffb3d76b75223e8ffed124e65ee62097e4e73afb5fec6b993e7a"},
-    {file = "typed_ast-1.5.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:37e5349d1d5de2f4763d534ccb26809d1c24b180a477659a12c4bde9dd677d74"},
-    {file = "typed_ast-1.5.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9f1a27592fac87daa4e3f16538713d705599b0a27dfe25518b80b6b017f0a6d"},
-    {file = "typed_ast-1.5.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8831479695eadc8b5ffed06fdfb3e424adc37962a75925668deeb503f446c0a3"},
-    {file = "typed_ast-1.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:20d5118e494478ef2d3a2702d964dae830aedd7b4d3b626d003eea526be18718"},
-    {file = "typed_ast-1.5.3.tar.gz", hash = "sha256:27f25232e2dd0edfe1f019d6bfaaf11e86e657d9bdb7b0956db95f560cceb2b3"},
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
+    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
+    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
+    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
+    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,20 @@ exclude = ["^tests/fixtures/"]
 [[tool.mypy.overrides]]
 module = [
   'cleo.*',
-  'poetry.*',
-  'poetry.core.*',
 ]
 ignore_missing_imports = true
+
+# use of importlib-metadata backport at python3.7 makes it impossible to
+# satisfy mypy without some ignores: but we get a different set of ignores at
+# different python versions.
+#
+# <https://github.com/python/mypy/issues/8823>, meanwhile suppress that
+# warning.
+[[tool.mypy.overrides]]
+module = [
+  'poetry_plugin_export',
+]
+warn_unused_ignores = false
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ poetry = "^1.2.0b1dev0"
 pre-commit = "^2.18"
 pytest = "^7.1"
 pytest-mock = "^3.6.1"
-poetry = {git = "https://github.com/abn/poetry.git", rev = "use-export-plugin"}
+poetry = {git = "https://github.com/python-poetry/poetry.git"}
 mypy = ">=0.950"
 
 [tool.poetry.plugins."poetry.application.plugin"]

--- a/src/poetry_plugin_export/__init__.py
+++ b/src/poetry_plugin_export/__init__.py
@@ -3,4 +3,4 @@ from __future__ import annotations
 from poetry.utils._compat import metadata
 
 
-__version__ = metadata.version("poetry-plugin-export")
+__version__ = metadata.version("poetry-plugin-export")  # type: ignore[no-untyped-call]

--- a/src/poetry_plugin_export/command.py
+++ b/src/poetry_plugin_export/command.py
@@ -12,7 +12,7 @@ except ImportError:
 from poetry_plugin_export.exporter import Exporter
 
 
-class ExportCommand(InstallerCommand):  # type: ignore[misc]
+class ExportCommand(InstallerCommand):
     name = "export"
     description = "Exports the lock file to alternative formats."
 

--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -102,7 +102,7 @@ class Exporter:
         ops = solver.solve().calculate_operations()
         packages = sorted(
             (op.package for op in ops),
-            key=lambda pkg: pkg.name,  # type: ignore[no-any-return]
+            key=lambda pkg: pkg.name,
         )
 
         for dependency_package in self._poetry.locker.get_project_dependency_packages(

--- a/src/poetry_plugin_export/plugins.py
+++ b/src/poetry_plugin_export/plugins.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from poetry.console.commands.command import Command
 
 
-class ExportApplicationPlugin(ApplicationPlugin):  # type: ignore[misc]
+class ExportApplicationPlugin(ApplicationPlugin):
     @property
     def commands(self) -> list[type[Command]]:
         return [ExportCommand]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,24 +31,24 @@ if TYPE_CHECKING:
     from tests.types import ProjectFactory
 
 
-class Config(BaseConfig):  # type: ignore[misc]
+class Config(BaseConfig):
     def get(self, setting_name: str, default: Any = None) -> Any:
-        self.merge(self._config_source.config)
-        self.merge(self._auth_config_source.config)
+        self.merge(self._config_source.config)  # type: ignore[attr-defined]
+        self.merge(self._auth_config_source.config)  # type: ignore[attr-defined]
 
         return super().get(setting_name, default=default)
 
     def raw(self) -> dict[str, Any]:
-        self.merge(self._config_source.config)
-        self.merge(self._auth_config_source.config)
+        self.merge(self._config_source.config)  # type: ignore[attr-defined]
+        self.merge(self._auth_config_source.config)  # type: ignore[attr-defined]
 
-        return super().raw()  # type: ignore[no-any-return]
+        return super().raw()
 
     def all(self) -> dict[str, Any]:
-        self.merge(self._config_source.config)
-        self.merge(self._auth_config_source.config)
+        self.merge(self._config_source.config)  # type: ignore[attr-defined]
+        self.merge(self._auth_config_source.config)  # type: ignore[attr-defined]
 
-        return super().all()  # type: ignore[no-any-return]
+        return super().all()
 
 
 @pytest.fixture
@@ -139,8 +139,8 @@ def current_env() -> SystemEnv:
 
 
 @pytest.fixture(scope="session")
-def current_python(current_env: SystemEnv) -> tuple[int, int, int]:
-    return current_env.version_info[:3]  # type: ignore[no-any-return]
+def current_python(current_env: SystemEnv) -> tuple[Any, ...]:
+    return current_env.version_info[:3]
 
 
 @pytest.fixture(scope="session")
@@ -159,7 +159,7 @@ def project_factory(
     workspace = Path(tmp_dir)
 
     def _factory(
-        name: str | None = None,
+        name: str,
         dependencies: dict[str, str] | None = None,
         dev_dependencies: dict[str, str] | None = None,
         pyproject_content: str | None = None,
@@ -183,8 +183,8 @@ def project_factory(
                 author="PyTest Tester <mc.testy@testface.com>",
                 readme_format="md",
                 python=default_python,
-                dependencies=dependencies,
-                dev_dependencies=dev_dependencies,
+                dependencies=dict(dependencies),
+                dev_dependencies=dict(dev_dependencies),
             ).create(project_dir, with_tests=False)
 
         if poetry_lock_content:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from tests.types import FixtureDirGetter
 
 
-class Locker(BaseLocker):  # type: ignore[misc]
+class Locker(BaseLocker):
     def __init__(self) -> None:
         self._lock = TOMLFile(Path.cwd().joinpath("poetry.lock"))
         self._locked = True
@@ -57,7 +57,7 @@ class Locker(BaseLocker):  # type: ignore[misc]
         return self
 
     def mock_lock_data(self, data: dict[str, Any]) -> None:
-        self._lock_data = data
+        self._lock_data = data  # type: ignore[assignment]
 
     def is_locked(self) -> bool:
         return self._locked
@@ -111,7 +111,7 @@ def set_package_requires(poetry: Poetry, skip: set[str] | None = None) -> None:
 def test_exporter_can_export_requirements_txt_with_standard_packages(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -155,7 +155,7 @@ foo==1.2.3 ; {MARKER_PY}
 def test_exporter_can_export_requirements_txt_with_standard_packages_and_markers(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -212,7 +212,7 @@ def test_exporter_can_export_requirements_txt_poetry(
 ) -> None:
     """Regression test for #3254"""
 
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -333,7 +333,7 @@ def test_exporter_can_export_requirements_txt_pyinstaller(
 ) -> None:
     """Regression test for #3254"""
 
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -413,7 +413,7 @@ def test_exporter_can_export_requirements_txt_pyinstaller(
 def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -508,7 +508,7 @@ def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers(
 def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers_any(
     tmp_dir: str, poetry: Poetry, dev: bool, lines: list[str]
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -562,7 +562,7 @@ def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers_a
 def test_exporter_can_export_requirements_txt_with_standard_packages_and_hashes(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -608,7 +608,7 @@ foo==1.2.3 ; {MARKER_PY} \\
 def test_exporter_can_export_requirements_txt_with_standard_packages_and_sorted_hashes(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -656,7 +656,7 @@ foo==1.2.3 ; {MARKER_PY} \\
 def test_exporter_requirements_txt_with_standard_packages_and_hashes_disabled(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -701,7 +701,7 @@ foo==1.2.3 ; {MARKER_PY}
 def test_exporter_exports_requirements_txt_without_dev_packages_by_default(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -745,7 +745,7 @@ foo==1.2.3 ; {MARKER_PY} \\
 def test_exporter_exports_requirements_txt_with_dev_packages_if_opted_in(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -792,7 +792,7 @@ foo==1.2.3 ; {MARKER_PY} \\
 def test_exporter_exports_requirements_txt_without_groups_if_set_explicity(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -832,7 +832,7 @@ def test_exporter_exports_requirements_txt_without_groups_if_set_explicity(
 def test_exporter_exports_requirements_txt_without_optional_packages(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -909,7 +909,7 @@ def test_exporter_exports_requirements_txt_with_optional_packages(
     extras: bool | list[str] | None,
     lines: list[str],
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -966,7 +966,7 @@ def test_exporter_exports_requirements_txt_with_optional_packages(
 def test_exporter_can_export_requirements_txt_with_git_packages(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1007,7 +1007,7 @@ foo @ git+https://github.com/foo/foo.git@123456 ; {MARKER_PY}
 def test_exporter_can_export_requirements_txt_with_nested_packages(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1062,7 +1062,7 @@ foo @ git+https://github.com/foo/foo.git@123456 ; {MARKER_PY}
 def test_exporter_can_export_requirements_txt_with_nested_packages_cyclic(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1117,7 +1117,7 @@ foo==1.2.3 ; {MARKER_PY}
 def test_exporter_can_export_requirements_txt_with_nested_packages_and_multiple_markers(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1191,7 +1191,7 @@ foo==1.2.3 ; {MARKER_PY}
 def test_exporter_can_export_requirements_txt_with_git_packages_and_markers(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1233,7 +1233,7 @@ foo @ git+https://github.com/foo/foo.git@123456 ; {MARKER_PY27.union(MARKER_PY36
 def test_exporter_can_export_requirements_txt_with_directory_packages(
     tmp_dir: str, poetry: Poetry, working_directory: Path
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1274,7 +1274,7 @@ foo @ {working_directory.as_uri()}/tests/fixtures/sample_project ; {MARKER_PY}
 def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
     tmp_dir: str, poetry: Poetry, working_directory: Path
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1348,7 +1348,7 @@ foo @ {root_uri}/sample_project ; {MARKER_PY}
 def test_exporter_can_export_requirements_txt_with_directory_packages_and_markers(
     tmp_dir: str, poetry: Poetry, working_directory: Path
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1391,7 +1391,7 @@ foo @ {working_directory.as_uri()}/tests/fixtures/sample_project ;\
 def test_exporter_can_export_requirements_txt_with_file_packages(
     tmp_dir: str, poetry: Poetry, working_directory: Path
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1433,7 +1433,7 @@ foo @ {working_directory.as_uri()}/tests/fixtures/distributions/demo-0.1.0.tar.g
 def test_exporter_can_export_requirements_txt_with_file_packages_and_markers(
     tmp_dir: str, poetry: Poetry, working_directory: Path
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1482,7 +1482,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages(
             "https://example.com/simple",
         )
     )
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1542,7 +1542,7 @@ def test_exporter_exports_requirements_txt_with_url_false(
             "https://example.com/simple",
         )
     )
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1601,7 +1601,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages_trusted_host(
             "http://example.com/simple",
         )
     )
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1666,7 +1666,7 @@ bar==4.5.6 ; {MARKER_PY} \\
 def test_exporter_exports_requirements_txt_with_dev_extras(
     tmp_dir: str, poetry: Poetry, dev: bool, expected: list[str]
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1734,7 +1734,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages_and_duplicate_so
             "https://foobaz.com/simple",
         )
     )
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1817,7 +1817,7 @@ def test_exporter_exports_requirements_txt_with_legacy_packages_and_credentials(
     poetry.pool.add_repository(
         LegacyRepository("custom", "https://example.com/simple", config=poetry.config)
     )
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1876,7 +1876,7 @@ foo==1.2.3 ; {MARKER_PY} \\
 def test_exporter_exports_requirements_txt_to_standard_output(
     tmp_dir: str, poetry: Poetry
 ) -> None:
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -1919,7 +1919,7 @@ def test_exporter_doesnt_confuse_repeated_packages(
     tmp_dir: str, poetry: Poetry
 ) -> None:
     # Testcase derived from <https://github.com/python-poetry/poetry/issues/5141>.
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {
@@ -2039,7 +2039,7 @@ def test_exporter_handles_extras_next_to_non_extras(
     tmp_dir: str, poetry: Poetry
 ) -> None:
     # Testcase similar to the solver testcase added at #5305.
-    poetry.locker.mock_lock_data(
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
         {
             "package": [
                 {

--- a/tests/types.py
+++ b/tests/types.py
@@ -29,7 +29,7 @@ class CommandTesterFactory(Protocol):
 class ProjectFactory(Protocol):
     def __call__(
         self,
-        name: str | None = None,
+        name: str,
         dependencies: dict[str, str] | None = None,
         dev_dependencies: dict[str, str] | None = None,
         pyproject_content: str | None = None,


### PR DESCRIPTION
`poetry.core` is now typed :boom:

aaaand, we can also unignore `poetry` since we're installing from git here