### PR TITLE
export complete package names (including features)

### DIFF
--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -132,9 +132,9 @@ class Exporter:
             elif is_direct_local_reference:
                 assert dependency.source_url is not None
                 dependency_uri = path_to_url(dependency.source_url)
-                line = f"{dependency.name} @ {dependency_uri}"
+                line = f"{package.complete_name} @ {dependency_uri}"
             else:
-                line = f"{package.name}=={package.version}"
+                line = f"{package.complete_name}=={package.version}"
 
             if not is_direct_remote_reference and ";" in requirement:
                 markers = requirement.split(";", 1)[1].strip()


### PR DESCRIPTION
I have in mind a fix to https://github.com/python-poetry/poetry/issues/5537 such that the packages returned by `get_project_dependency_packages()` include any features that ought to be installed.

Then this fix will cause those features to be included at export.

(Except for local dependencies, which I suppose would need some different fix.  I don't intend to do anything about that in this MR: it's getting a touch complicated and I don't myself care about exporting `requirements.txt` for local dependencies).