### PR TITLE
fixed testcase exporting extras

### DIFF
--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -2138,7 +2138,8 @@ def test_exporter_handles_extras_next_to_non_extras(
 
     expected = f"""\
 localstack-ext==1.0.0 ; {MARKER_PY36}
-localstack==1.0.0 ; {MARKER_PY36}
+localstack-ext[bar]==1.0.0 ; {MARKER_PY36}
+localstack[foo]==1.0.0 ; {MARKER_PY36}
 something-else==1.0.0 ; {MARKER_PY36}
 something==1.0.0 ; {MARKER_PY36}
 """


### PR DESCRIPTION
If https://github.com/python-poetry/poetry/pull/5688 is merged, the new behaviour will be per this updated testcase.

I don't think that either this or that MR can be merged before the other without there being some intermediate breakage of tests. 