### PR TITLE
more accurate mock lock data

### DIFF
--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -2058,7 +2058,7 @@ def test_exporter_handles_extras_next_to_non_extras(
                             },
                         ]
                     },
-                    "extras": {"foo": ["localstack-ext (>=1.0.0)"]},
+                    "extras": {"foo": ["localstack-ext[bar] (>=1.0.0)"]},
                 },
                 {
                     "name": "localstack-ext",


### PR DESCRIPTION
This update to the mock data in one of the tests matches what poetry actually does, and I think would be sufficient to allow https://github.com/python-poetry/poetry/pull/5819 to pass its pipelines.

ie the proposed sequence is: merge this, merge https://github.com/python-poetry/poetry/pull/5819, merge #73.

(modulo review agreeing that any of these want merging at all, obviously)