### PR TITLE
add private attribute to fit the implementation of the mocked class

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -43,6 +43,7 @@ class TestLocker(Locker):
         self._content_hash = self._get_content_hash()
         self._locked = False
         self._write = False
+        self._contains_credential = False
 
     def write(self, write: bool = True) -> None:
         self._write = write


### PR DESCRIPTION
The equivalent of the attribute `Locker._contains_credential` needs to be added to `TestLocker` to mock it properly.


This patch is needed to fix the tests error in PR https://github.com/python-poetry/poetry/pull/3995 (which adds the `_contains_credential` attribute)