### PR TITLE
remove deprecated usage of Factory.create_config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def config(
     c.set_config_source(config_source)
     c.set_auth_config_source(auth_config_source)
 
-    mocker.patch("poetry.factory.Factory.create_config", return_value=c)
+    mocker.patch("poetry.config.config.Config.create", return_value=c)
     mocker.patch("poetry.config.config.Config.set_config_source")
 
     return c


### PR DESCRIPTION
https://github.com/python-poetry/poetry/blob/35281d9b2de77cb47c3ba2bf372e1b31e4c75d87/src/poetry/factory.py#L64-L67

