### PR TITLE
pay attention to package sources in export

### DIFF
--- a/src/poetry_plugin_export/walker.py
+++ b/src/poetry_plugin_export/walker.py
@@ -229,6 +229,7 @@ def get_locked_package(
         for package in candidates
         if package.python_constraint.allows_all(dependency.python_constraint)
         and dependency.constraint.allows(package.version)
+        and (dependency.source_type is None or dependency.is_same_source_as(package))
     ]
 
     # If we have an overlapping candidate, we must use it.


### PR DESCRIPTION
previously the exporter would see two packages from different sources as the same, combine their markers, and produce nonsense like this:
```
foo @ https://example.com/foo-darwin.whl ; python_version >= "3.6" and python_version < "4.0" and sys_platform == "linux" or python_version >= "3.6" and python_version < "4.0" and sys_platform == "darwin"
```