### PR TITLE
release: bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [1.1.0] - 2022-10-01
+
+### Added
+
+- Add support for exporting `constraints.txt` files ([#128](https://github.com/python-poetry/poetry-plugin-export/pull/128)).
+
+### Fixed
+
+- Fix an issue where a relative path passed via `-o` was not ìnterpreted relative to the current working directory ([#130](https://github.com/python-poetry/poetry-plugin-export/pull/130)).
+- Fix an issue where the names of extras were not normalized according to PEP 685 ([#123](https://github.com/python-poetry/poetry-plugin-export/pull/123)).
+
+
 ## [1.0.7] - 2022-09-13
 
 ### Added
@@ -16,11 +28,13 @@
 - Fix an issue where exporting a dependency on a package with a non-existent extra fails ([#109](https://github.com/python-poetry/poetry-plugin-export/pull/109)).
 - Fix an issue where only one of `--index-url` and `--extra-index-url` were exported ([#117](https://github.com/python-poetry/poetry-plugin-export/pull/117)).
 
+
 ## [1.0.6] - 2022-08-07
 
 ### Fixed
 
 - Fixed an issue the markers of exported dependencies overlapped. [#94](https://github.com/python-poetry/poetry-plugin-export/pull/94)
+
 
 ## [1.0.5] - 2022-07-12
 
@@ -28,15 +42,18 @@
 
 - Added LICENSE file. [#81](https://github.com/python-poetry/poetry-plugin-export/pull/81)
 
+
 ## [1.0.4] - 2022-05-26
 
 ### Fixed
 
 - Fixed an issue where the exported dependencies did not list their active extras. [#65](https://github.com/python-poetry/poetry-plugin-export/pull/65)
 
+
 ## [1.0.3] - 2022-05-23
 
 This release fixes test suite compatibility with upcoming Poetry releases. No functional changes.
+
 
 ## [1.0.2] - 2022-05-10
 
@@ -54,6 +71,7 @@ This release fixes test suite compatibility with upcoming Poetry releases. No fu
 ### Fixed
 
 - Fixed a regression where export incorrectly always exported default group only. [#50](https://github.com/python-poetry/poetry-plugin-export/pull/50)
+
 
 ## [1.0.0] - 2022-04-05
 
@@ -86,7 +104,8 @@ This release fixes test suite compatibility with upcoming Poetry releases. No fu
 - Added support for dependency groups. [#6](https://github.com/python-poetry/poetry-plugin-export/pull/6)
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.0.7...main
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.1.0...main
+[1.1.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.1.0
 [1.0.7]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.0.7
 [1.0.6]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.0.6
 [1.0.5]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-export"
-version = "1.0.7"
+version = "1.1.0"
 description = "Poetry plugin to export the dependencies to various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"


### PR DESCRIPTION
### Added

- Add support for exporting `constraints.txt` files ([#128](https://github.com/python-poetry/poetry-plugin-export/pull/128)).

### Fixed

- Fix an issue where a relative path passed via `-o` was not ìnterpreted relative to the current working directory ([#130](https://github.com/python-poetry/poetry-plugin-export/pull/130)).
- Fix an issue where the names of extras were not normalized according to PEP 685 ([#123](https://github.com/python-poetry/poetry-plugin-export/pull/123)).