### PR TITLE
chore: avoid deprecation warning when used with poetry-core >= 1.3

### DIFF
--- a/src/poetry_plugin_export/walker.py
+++ b/src/poetry_plugin_export/walker.py
@@ -3,7 +3,20 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from packaging.utils import canonicalize_name
-from poetry.core.semver.util import constraint_regions
+
+
+try:
+    # turn isort off because it moves the "type: ignore" to the next line
+    # isort: off
+    from poetry.core.constraints.version.util import (  # type: ignore[import]
+        constraint_regions,
+    )
+
+    # isort: on
+except ImportError:
+    # poetry-core < 1.3
+    from poetry.core.semver.util import constraint_regions
+
 from poetry.core.version.markers import AnyMarker
 from poetry.core.version.markers import SingleMarker
 from poetry.packages import DependencyPackage


### PR DESCRIPTION
Alternative approach to #138, since we can't bump poetry-core here until a new poetry release which is compatible with that core version. However, it would be nice to avoid the deprecation warning in the upcoming poetry release.