### PR TITLE
release: bump version to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.1.2] - 2022-10-09
+
+### Fixed
+
+- Fix an issue where exporting a `constraints.txt` file fails if an editable dependency is locked ([#140](https://github.com/python-poetry/poetry-plugin-export/pull/140)).
+
+
 ## [1.1.1] - 2022-10-03
 
 This release fixes test suite compatibility with upcoming Poetry releases. No functional changes.
@@ -109,7 +116,8 @@ This release fixes test suite compatibility with upcoming Poetry releases. No fu
 - Added support for dependency groups. [#6](https://github.com/python-poetry/poetry-plugin-export/pull/6)
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.1.1...main
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.1.2...main
+[1.1.2]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.1.2
 [1.1.1]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.1.1
 [1.1.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.1.0
 [1.0.7]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-export"
-version = "1.1.1"
+version = "1.1.2"
 description = "Poetry plugin to export the dependencies to various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"


### PR DESCRIPTION
### Fixed

- Fix an issue where exporting a `constraints.txt` file fails if an editable dependency is locked ([#140](https://github.com/python-poetry/poetry-plugin-export/pull/140)).