### PR TITLE
release: bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+
+## [1.2.0] - 2022-11-05
+
+### Changed
+
+- Drop some compatibility code and bump minimum required poetry version to 1.2.2 ([#143](https://github.com/python-poetry/poetry-plugin-export/pull/143)).
+- Ensure compatibility with upcoming Poetry releases ([#151](https://github.com/python-poetry/poetry-plugin-export/pull/151)).
+
+
 ## [1.1.2] - 2022-10-09
 
 ### Fixed
@@ -116,7 +125,8 @@ This release fixes test suite compatibility with upcoming Poetry releases. No fu
 - Added support for dependency groups. [#6](https://github.com/python-poetry/poetry-plugin-export/pull/6)
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.1.2...main
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.2.0...main
+[1.2.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.2.0
 [1.1.2]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.1.2
 [1.1.1]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.1.1
 [1.1.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-export"
-version = "1.2.0.dev0"
+version = "1.2.0"
 description = "Poetry plugin to export the dependencies to various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"


### PR DESCRIPTION
### Changed

- Drop some compatibility code and bump minimum required poetry version to 1.2.2 ([#143](https://github.com/python-poetry/poetry-plugin-export/pull/143)).
- Ensure compatibility with upcoming Poetry releases ([#151](https://github.com/python-poetry/poetry-plugin-export/pull/151)).