### PR TITLE
fix: create parent dir if not present in the ouput param path

### DIFF
--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -8,6 +8,8 @@ from typing import Iterable
 
 from cleo.io.io import IO
 from poetry.core.packages.dependency_group import MAIN_GROUP
+from pathlib import Path
+import os
 
 
 try:
@@ -211,6 +213,7 @@ class Exporter:
         if isinstance(output, IO):
             output.write(content)
         else:
+            Path(os.path.dirname(output)).mkdir(parents=True, exist_ok=True)
             with (cwd / output).open("w", encoding="utf-8") as txt:
                 txt.write(content)
 


### PR DESCRIPTION
When using the command of the below format
poetry export -o package/lib/requirements.txt

In the above example, if the package/lib directory doesn't exist, the above command would fail. With the fix, the tool would create all the necessary intermediate folders to the file path provided and export the dependencies to the file provided.