### PR TITLE
tests: use_executor(True) is default

### DIFF
--- a/tests/command/conftest.py
+++ b/tests/command/conftest.py
@@ -81,7 +81,6 @@ def command_tester_factory(
                 executor=executor
                 or TestExecutor(env, poetry.pool, poetry.config, tester.io),
             )
-            installer.use_executor(True)
             cmd.set_installer(installer)
 
         return tester


### PR DESCRIPTION
preparation for this option being removed altogether from poetry proper, per https://github.com/python-poetry/poetry/pull/7356