### PR TITLE
Add test and detailed error message for unsupported dependency case 

### DIFF
--- a/src/poetry_plugin_export/walker.py
+++ b/src/poetry_plugin_export/walker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING
 
 from packaging.utils import canonicalize_name
 from poetry.core.constraints.version.util import constraint_regions

--- a/src/poetry_plugin_export/walker.py
+++ b/src/poetry_plugin_export/walker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Set
 
 from packaging.utils import canonicalize_name
 from poetry.core.constraints.version.util import constraint_regions
@@ -242,10 +242,24 @@ def get_locked_package(
 
     # If we have an overlapping candidate, we must use it.
     if overlapping_candidates:
-        compatible_candidates = [
+        filtered_compatible_candidates = [
             package
             for package in compatible_candidates
             if package in overlapping_candidates
         ]
 
+        if not filtered_compatible_candidates:
+            # TODO: Support this case: https://github.com/python-poetry/poetry-plugin-export/issues/183
+            raise DependencyWalkerError(
+                f"The `{dependency.name}` package has the following compatible candidates `{compatible_candidates}`; "
+                f" but, the exporter dependency walker previously elected `{overlapping_candidates.pop()}` "
+                f"which is not compatible with the dependency `{dependency}`. "
+                "Please contribute to `poetry-plugin-export` to solve this problem.")
+
+        compatible_candidates = filtered_compatible_candidates
+
     return next(iter(compatible_candidates), None)
+
+
+class DependencyWalkerError(Exception):
+    pass

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,0 +1,16 @@
+from poetry_plugin_export.walker import walk_dependencies, DependencyWalkerError
+
+from poetry.core.packages.dependency import Dependency
+from poetry.core.packages.package import Package
+import pytest
+
+
+def test_walk_dependencies_multiple_versions_when_latest_is_not_compatible():
+    
+    # TODO: Support this case: https://github.com/python-poetry/poetry-plugin-export/issues/183
+    with pytest.raises(DependencyWalkerError):
+        walk_dependencies(
+            dependencies=[Dependency("grpcio", ">=1.42.0"), Dependency("grpcio", ">=1.42.0,<=1.49.1"), Dependency("grpcio", ">=1.47.0,<2.0dev")],
+            packages_by_name={"grpcio": [Package('grpcio', '1.51.3'), Package('grpcio', '1.49.1')]},
+            root_package_name="package-name"
+        )


### PR DESCRIPTION
As per #183, if one package has multiple possible dependency versions, the dependency walker may fall into a trap where it discards the final "good" version.
The dependency walker requires quite a refactor to support this, and there are not tests to perform such a refactor in a confident manner.

Meanwhile, I propose this PR that at least details a bit better the problem so that users more easily investigate a work around.