### PR TITLE
allow multiple indexes to be trusted hosts

### DIFF
--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -170,6 +170,7 @@ class Exporter:
         if indexes and self._with_urls:
             # If we have extra indexes, we add them to the beginning of the output
             indexes_header = ""
+            trusted_hosts = []
             for index in sorted(indexes):
                 repositories = [
                     r
@@ -189,19 +190,25 @@ class Exporter:
                         else repository.url
                     )
                     indexes_header += f"--index-url {url}\n"
-                    continue
+                else:
+                    url = (
+                        repository.authenticated_url
+                        if self._with_credentials
+                        else repository.url
+                    )
 
-                url = (
-                    repository.authenticated_url
-                    if self._with_credentials
-                    else repository.url
-                )
                 parsed_url = urllib.parse.urlsplit(url)
                 if parsed_url.scheme == "http":
-                    indexes_header += f"--trusted-host {parsed_url.netloc}\n"
-                indexes_header += f"--extra-index-url {url}\n"
+                    trusted_hosts.append(parsed_url.netloc)
 
-            content = indexes_header + "\n" + content
+                if repository is not self._poetry.pool.repositories[0]:
+                    indexes_header += f"--extra-index-url {url}\n"
+
+            trusted_cmdopts = ""
+            for host in trusted_hosts:
+                trusted_cmdopts += f"--trusted-host {host}\n"
+
+            content = trusted_cmdopts + indexes_header + "\n" + content
 
         if isinstance(output, IO):
             output.write(content)


### PR DESCRIPTION
## Use-Case
This change/enhancement handles a case where my primary repository (Artifactory) is the only machine on the network allowed to talk to pypi.org. All consumers of PyPI packages _must_ pull from Artifactory exclusively.

For business reasons, I cannot have the internal CA certificate installed on all points of consumption. For this reason we pull packages over plain-text HTTP. The business has agreed to risks involved.

## Current State
Today, I have a single default source in my `pyproject.toml` file that looks something like:

```
[[tool.poetry.source]]
name = "foo"
url = "http://foo.internal.bar/simple/"
default = true
secondary = false
```

Because it is the default repository, it [skips the part of the code](https://github.com/python-poetry/poetry-plugin-export/blob/main/src/poetry_plugin_export/exporter.py#L192) that is responsible for appending `--trusted-host`.

So I propose this change to allow me to add my default repository as a trusted host.

Pip's options append each `--trusted-host HOST` see: https://github.com/pypa/pip/blob/main/src/pip/_internal/cli/cmdoptions.py#L397