### PR TITLE
release: bump version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log
 
 
+## [1.3.1] - 2023-04-17
+
+This release mainly fixes test suite compatibility with upcoming Poetry releases.
+
+### Changed
+
+- Improve error message in some cases when the dependency walk fails ([#184](https://github.com/python-poetry/poetry-plugin-export/pull/184)).
+
+
 ## [1.3.0] - 2023-01-30
 
 ### Changed
@@ -136,7 +145,8 @@ This release fixes test suite compatibility with upcoming Poetry releases. No fu
 - Added support for dependency groups. [#6](https://github.com/python-poetry/poetry-plugin-export/pull/6)
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.3.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.3.1...main
+[1.3.1]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.3.1
 [1.3.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.3.0
 [1.2.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.2.0
 [1.1.2]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-export"
-version = "1.3.0"
+version = "1.3.1"
 description = "Poetry plugin to export the dependencies to various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"


### PR DESCRIPTION
This release mainly fixes test suite compatibility with upcoming Poetry releases.

### Changed

- Improve error message in some cases when the dependency walk fails ([#184](https://github.com/python-poetry/poetry-plugin-export/pull/184)).