### PR TITLE
Fix: Include explicit sources in export command

### DIFF
--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -173,7 +173,7 @@ class Exporter:
             for index in sorted(indexes):
                 repositories = [
                     r
-                    for r in self._poetry.pool.repositories
+                    for r in self._poetry.pool.all_repositories
                     if isinstance(r, HTTPRepository) and r.url == index.rstrip("/")
                 ]
                 if not repositories:


### PR DESCRIPTION
This PR addresses an issue where the `poetry export` command was not exporting the `--extra-index-url` and `--trusted-host` options as expected for `explicit` sources.

Previously, the `Exporter` class was calling the `repositories` property from the `RepositoryPool` in the `poetry` package to fetch all repository information. However, `repositories` excludes `explicit` repositories.

To resolve this issue, I have modified the `Exporter` class to use the `all_repositories` property instead of `repositories`. The `all_repositories` property includes `explicit` repositories and ensures the `--extra-index-url` and `--trusted-host` options are exported correctly.

fixes: https://github.com/python-poetry/poetry-plugin-export/issues/204

