### PR TITLE
strip extras properly from marker during dependency walk

### DIFF
--- a/src/poetry_plugin_export/walker.py
+++ b/src/poetry_plugin_export/walker.py
@@ -173,7 +173,7 @@ def walk_dependencies(
             ):
                 continue
 
-            base_marker = require.marker.intersect(requirement.marker.without_extras())
+            base_marker = require.marker.intersect(requirement.marker).without_extras()
 
             if not base_marker.is_empty():
                 # So as to give ourselves enough flexibility in choosing a solution,


### PR DESCRIPTION
Fixes #208 

the walk first finds `typer[all]`, then from that derives the requirement `colorama ; extra == ["all"]`, then accidentally preserves that marker which later causes some sort of confusion.

Once it has established that `colorama` is needed, the fact that it was because a `typer` feature was enabled should be irrelevant.  The code already almost stripped extras from markers as it propagated them; it just made a bit of a mess of it.