### PR TITLE
Improve warning message when lockfile is not up-to-date

### DIFF
--- a/src/poetry_plugin_export/command.py
+++ b/src/poetry_plugin_export/command.py
@@ -81,10 +81,9 @@ class ExportCommand(GroupCommand):
         if not locker.is_fresh():
             self.line_error(
                 "<warning>"
-                "Warning: The lock file is not up to date with "
-                "the latest changes in pyproject.toml. "
-                "You may be getting outdated dependencies. "
-                "Run update to update them."
+                "Warning: poetry.lock is not consistent with pyproject.toml. "
+                "You may be getting improper dependencies. "
+                "Run `poetry lock [--no-update]` to fix it."
                 "</warning>"
             )
 


### PR DESCRIPTION
For people not very familiar with `poetry`, it was not clear what "run update" means.

"run `poetry update`" makes this obvious.