### PR TITLE
release: bump version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 
 
+## [1.5.0] - 2023-08-20
+
+### Changed
+
+- Drop support for Python 3.7 ([#189](https://github.com/python-poetry/poetry-plugin-export/pull/189)).
+- Improve warning when the lock file is not consistent with pyproject.toml ([#215](https://github.com/python-poetry/poetry-plugin-export/pull/215)).
+
+### Fixed
+
+- Fix an issue where markers for dependencies required by an extra were not generated correctly ([#209](https://github.com/python-poetry/poetry-plugin-export/pull/209)).
+
+
 ## [1.4.0] - 2023-05-29
 
 ### Changed
@@ -156,7 +168,8 @@ This release fixes test suite compatibility with upcoming Poetry releases. No fu
 - Added support for dependency groups. [#6](https://github.com/python-poetry/poetry-plugin-export/pull/6)
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.4.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.5.0...main
+[1.5.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.5.0
 [1.4.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.4.0
 [1.3.1]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.3.1
 [1.3.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-export"
-version = "1.4.0"
+version = "1.5.0"
 description = "Poetry plugin to export the dependencies to various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -447,7 +447,7 @@ def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers(
         "b": Dependency.create_from_pep_508(f"b==4.5.6 ; {marker_py_windows}"),
         "c": Dependency.create_from_pep_508(f"c==7.8.9 ; {marker_py_win32}"),
         "d": Dependency.create_from_pep_508(
-            f"d==0.0.1 ; {marker_py_win32.union(marker_py_windows)}"
+            f"d==0.0.1 ; {marker_py_windows.union(marker_py_win32)}"
         ),
     }
 


### PR DESCRIPTION
### Changed

- Drop support for Python 3.7 ([#189](https://github.com/python-poetry/poetry-plugin-export/pull/189)).
- Improve warning when the lock file is not consistent with pyproject.toml ([#215](https://github.com/python-poetry/poetry-plugin-export/pull/215)).

### Fixed

- Fix an issue where markers for dependencies required by an extra were not generated correctly ([#209](https://github.com/python-poetry/poetry-plugin-export/pull/209)).