### PR TITLE
Add a '--all-extras' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,6 @@ poetry export -f requirements.txt --output requirements.txt
 * `--default`: Only export the main dependencies. (**Deprecated**)
 * `--dev`: Include development dependencies. (**Deprecated**)
 * `--extras (-E)`: Extra sets of dependencies to include.
+* `--all-extras`: Include all sets of extra dependencies.
 * `--without-hashes`: Exclude hashes from the exported file.
 * `--with-credentials`: Include credentials for extra indices.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -73,5 +73,6 @@ poetry export --only test,docs
 * `--default`: Only export the main dependencies. (**Deprecated**)
 * {{< option name="dev" deprecated=true >}}Include development dependencies.{{< /option >}}
 * `--extras (-E)`: Extra sets of dependencies to include.
+* `--all-extras`: Include all sets of extra dependencies.
 * `--without-hashes`: Exclude hashes from the exported file.
 * `--with-credentials`: Include credentials for extra indices.

--- a/src/poetry_plugin_export/command.py
+++ b/src/poetry_plugin_export/command.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from cleo.helpers import option
+from packaging.utils import NormalizedName
 from packaging.utils import canonicalize_name
 from poetry.console.commands.group_command import GroupCommand
 from poetry.core.packages.dependency_group import MAIN_GROUP
 
 from poetry_plugin_export.exporter import Exporter
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class ExportCommand(GroupCommand):
@@ -43,8 +49,8 @@ class ExportCommand(GroupCommand):
             flag=False,
             multiple=True,
         ),
-        option("with-credentials", None, "Include credentials for extra indices."),
         option("all-extras", None, "Include all sets of extra dependencies."),
+        option("with-credentials", None, "Include credentials for extra indices."),
     ]
 
     @property
@@ -95,6 +101,7 @@ class ExportCommand(GroupCommand):
             )
             return 1
 
+        extras: Iterable[NormalizedName]
         if self.option("all-extras"):
             extras = self.poetry.package.extras.keys()
         else:

--- a/tests/command/test_command_export.py
+++ b/tests/command/test_command_export.py
@@ -220,6 +220,13 @@ def test_export_reports_invalid_extras(tester: CommandTester, do_lock: None) -> 
     assert str(error.value) == expected
 
 
+def test_export_with_all_extras(tester: CommandTester, do_lock: None) -> None:
+    tester.execute("--format requirements.txt --all-extras")
+    output = tester.io.fetch_output()
+    assert f"bar==1.1.0 ; {MARKER_PY}" in output
+    assert f"qux==1.2.0 ; {MARKER_PY}" in output
+
+
 def test_export_with_urls(
     monkeypatch: MonkeyPatch, tester: CommandTester, poetry: Poetry
 ) -> None:

--- a/tests/command/test_command_export.py
+++ b/tests/command/test_command_export.py
@@ -227,6 +227,17 @@ def test_export_with_all_extras(tester: CommandTester, do_lock: None) -> None:
     assert f"qux==1.2.0 ; {MARKER_PY}" in output
 
 
+def test_extras_conflicts_all_extras(tester: CommandTester, do_lock: None) -> None:
+    tester.execute("--extras bar --all-extras")
+
+    assert tester.status_code == 1
+    assert (
+        tester.io.fetch_error()
+        == "You cannot specify explicit `--extras` while exporting using"
+        " `--all-extras`.\n"
+    )
+
+
 def test_export_with_urls(
     monkeypatch: MonkeyPatch, tester: CommandTester, poetry: Poetry
 ) -> None:


### PR DESCRIPTION
In my team, we are exporting the dependencies of some of our packages with the information from all extras to make sure that we have the same environment for different test and deployment scenarios. With time, we have been adding more extras and have had to update our configurations each time there is a new extra.

With this option, we don't have to care anymore about the extras explicitly and know that we'll always have the information we need correctly exported. We hope that this would be useful enough for other packages to be integrated into the official version of this plugin.