### PR TITLE
release: bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Change Log
 
 
+## [1.6.0] - 2023-10-30
+
+### Added
+
+- Add an `--all-extras` option ([#241](https://github.com/python-poetry/poetry-plugin-export/pull/241)).
+
+### Fixed
+
+- Fix an issue where git dependencies are exported with the branch name instead of the resolved commit hash ([#213](https://github.com/python-poetry/poetry-plugin-export/pull/213)).
+
+
 ## [1.5.0] - 2023-08-20
 
 ### Changed
@@ -168,7 +179,8 @@ This release fixes test suite compatibility with upcoming Poetry releases. No fu
 - Added support for dependency groups. [#6](https://github.com/python-poetry/poetry-plugin-export/pull/6)
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.5.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-export/compare/1.6.0...main
+[1.6.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.6.0
 [1.5.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.5.0
 [1.4.0]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.4.0
 [1.3.1]: https://github.com/python-poetry/poetry-plugin-export/releases/tag/1.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,14 @@
 [tool.poetry]
 name = "poetry-plugin-export"
-version = "1.5.0"
+version = "1.6.0"
 description = "Poetry plugin to export the dependencies to various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"
 readme = "README.md"
 homepage = "https://python-poetry.org/"
 repository = "https://github.com/python-poetry/poetry-plugin-export"
+# Classifiers for Python 3.12 can be removed after Poetry 1.7.0 has been released.
+classifiers = ["Programming Language :: Python :: 3.12"]
 
 packages = [
     { include = "poetry_plugin_export", from = "src" }

--- a/tests/command/test_command_export.py
+++ b/tests/command/test_command_export.py
@@ -232,9 +232,8 @@ def test_extras_conflicts_all_extras(tester: CommandTester, do_lock: None) -> No
 
     assert tester.status_code == 1
     assert (
-        tester.io.fetch_error()
-        == "You cannot specify explicit `--extras` while exporting using"
-        " `--all-extras`.\n"
+        "You cannot specify explicit `--extras` while exporting using `--all-extras`.\n"
+        in tester.io.fetch_error()
     )
 
 


### PR DESCRIPTION
### Added

- Add an `--all-extras` option ([#241](https://github.com/python-poetry/poetry-plugin-export/pull/241)).

### Fixed

- Fix an issue where git dependencies are exported with the branch name instead of the resolved commit hash ([#213](https://github.com/python-poetry/poetry-plugin-export/pull/213)).
