### PR TITLE
Add --check-change option, for pre-commit export hook

### DIFF
--- a/src/poetry_plugin_export/command.py
+++ b/src/poetry_plugin_export/command.py
@@ -74,7 +74,7 @@ class ExportCommand(GroupCommand):
             raise ValueError(f"Invalid export format: {fmt}")
 
         output = self.option("output")
-        output_path = Path(output)
+        output_path = Path(output) if output else None
 
         locker = self.poetry.locker
         if not locker.is_locked():

--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import urllib.parse
 
 from functools import partialmethod
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Iterable
 
@@ -15,7 +16,6 @@ from poetry_plugin_export.walker import get_project_dependency_packages
 
 if TYPE_CHECKING:
     from collections.abc import Collection
-    from pathlib import Path
     from typing import ClassVar
 
     from packaging.utils import NormalizedName
@@ -79,6 +79,14 @@ class Exporter:
             raise ValueError(f"Invalid export format: {fmt}")
 
         getattr(self, self.EXPORT_METHODS[fmt])(cwd, output)
+
+    def export_and_check_change(self, fmt: str, cwd: Path, output: str) -> bool:
+        output_path = Path(output)
+        orig_content = output_path.read_bytes() if output_path.exists() else None
+        self.export(fmt, cwd, output)
+        new_content = output_path.read_bytes()
+        changed = new_content != orig_content
+        return changed
 
     def _export_generic_txt(
         self, cwd: Path, output: IO | str, with_extras: bool, allow_editable: bool


### PR DESCRIPTION
This is required to fix https://github.com/python-poetry/poetry/issues/8512 / https://github.com/python-poetry/poetry-plugin-export/issues/237.

Currently, the poetry-export pre-commit hook returns 0 even when it changes the requirements.txt file. As written [here](https://pre-commit.com/#creating-new-hooks), pre-commit hooks should return a nonzero value when modifying files. This is required in order to make pipelines fail if files are not as expected - in this case, if the requirements.txt file was not updated.

I added a --check-change option, which causes `poetry export` to return 1 if it changed the output. https://github.com/python-poetry/poetry/pull/8810 in the main poetry repository changes the hook to add the `--check-change` option.

Note: I didn't add a test yet. If you approve of the approach, I'll happily add a test.