### PR TITLE
Adding -e flag to editable local references

### DIFF
--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -116,7 +116,6 @@ class Exporter:
                         " constraints.txt format.</warning>"
                     )
                     continue
-                line += "-e "
 
             requirement = dependency.to_pep_508(with_extras=False, resolved=True)
             is_direct_local_reference = (
@@ -129,7 +128,10 @@ class Exporter:
             elif is_direct_local_reference:
                 assert dependency.source_url is not None
                 dependency_uri = path_to_url(dependency.source_url)
-                line = f"{package.complete_name} @ {dependency_uri}"
+                if package.develop:
+                    line = f"-e {dependency_uri}"
+                else:
+                    line = f"{package.complete_name} @ {dependency_uri}"
             else:
                 line = f"{package.complete_name}=={package.version}"
 

--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -108,14 +108,13 @@ class Exporter:
             dependency = dependency_package.dependency
             package = dependency_package.package
 
-            if package.develop:
-                if not allow_editable:
-                    self._io.write_error_line(
-                        f"<warning>Warning: {package.pretty_name} is locked in develop"
-                        " (editable) mode, which is incompatible with the"
-                        " constraints.txt format.</warning>"
-                    )
-                    continue
+            if package.develop and not allow_editable:
+                self._io.write_error_line(
+                    f"<warning>Warning: {package.pretty_name} is locked in develop"
+                    " (editable) mode, which is incompatible with the"
+                    " constraints.txt format.</warning>"
+                )
+                continue
 
             requirement = dependency.to_pep_508(with_extras=False, resolved=True)
             is_direct_local_reference = (

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1300,7 +1300,8 @@ def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
                     "version": "7.8.9",
                     "optional": False,
                     "python-versions": "*",
-                    "source": {
+                    "develop": True,
+                "source": {
                         "type": "directory",
                         "url": "sample_project/../project_with_nested_local/bar/..",
                         "reference": "",
@@ -1323,8 +1324,8 @@ def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
         content = f.read()
 
     expected = f"""\
+-e {fixture_root_uri}/project_with_nested_local ; {MARKER_PY}
 bar @ {fixture_root_uri}/project_with_nested_local/bar ; {MARKER_PY}
-baz @ {fixture_root_uri}/project_with_nested_local ; {MARKER_PY}
 foo @ {fixture_root_uri}/sample_project ; {MARKER_PY}
 """
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1267,6 +1267,47 @@ foo @ {fixture_root_uri}/sample_project ; {MARKER_PY}
     assert content == expected
 
 
+def test_exporter_can_export_requirements_txt_with_directory_packages_editable(
+    tmp_path: Path, poetry: Poetry, fixture_root_uri: str
+) -> None:
+    poetry.locker.mock_lock_data(  # type: ignore[attr-defined]
+        {
+            "package": [
+                {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "optional": False,
+                    "python-versions": "*",
+                    "develop": True,
+                    "source": {
+                        "type": "directory",
+                        "url": "sample_project",
+                        "reference": "",
+                    },
+                }
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "files": {"foo": []},
+            },
+        }
+    )
+    set_package_requires(poetry)
+
+    exporter = Exporter(poetry, NullIO())
+    exporter.export("requirements.txt", tmp_path, "requirements.txt")
+
+    with (tmp_path / "requirements.txt").open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = f"""\
+-e {fixture_root_uri}/sample_project ; {MARKER_PY}
+"""
+
+    assert content == expected
+
+
 def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
     tmp_path: Path, poetry: Poetry, fixture_root_uri: str
 ) -> None:
@@ -1300,8 +1341,7 @@ def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
                     "version": "7.8.9",
                     "optional": False,
                     "python-versions": "*",
-                    "develop": True,
-                "source": {
+                    "source": {
                         "type": "directory",
                         "url": "sample_project/../project_with_nested_local/bar/..",
                         "reference": "",
@@ -1324,8 +1364,8 @@ def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
         content = f.read()
 
     expected = f"""\
--e {fixture_root_uri}/project_with_nested_local ; {MARKER_PY}
 bar @ {fixture_root_uri}/project_with_nested_local/bar ; {MARKER_PY}
+baz @ {fixture_root_uri}/project_with_nested_local ; {MARKER_PY}
 foo @ {fixture_root_uri}/sample_project ; {MARKER_PY}
 """
 


### PR DESCRIPTION
Resolves #145

Specifically, it takes the [approach suggested by @bow](https://github.com/python-poetry/poetry-plugin-export/issues/145#issuecomment-1274927714).

I would love some feedback from one of the maintainers. The issue has been open for quite some time, and I'm not entirely sure if this would be a desired behaviour.