### PR TITLE
relax poetry and poetry-core constraint to facilitate development of Poetry 2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1562,4 +1562,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c6a4469b36c3e26e5c6058bf931cb1fca0cd2cd8fd21d4d0d684d48b501ac19f"
+content-hash = "a307339f49db1e3c72043055981f0e715ae1892e9592fc74e3f11b64c3709303"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-poetry = "^1.8.0"
-poetry-core = "^1.7.0"
+poetry = ">=1.8.0,<3.0.0"
+poetry-core = ">=1.7.0,<3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=2.18"


### PR DESCRIPTION
I could not bump the version of poetry-core to 2.0.0.dev0 in python-poetry/poetry-core#708 for python-poetry/poetry#9135 because of this upper constraint. This change makes life easier until we drop the poetry-plugin-export dependency of poetry.