### PR TITLE
Make pre-commit hook regex more precise

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,5 +5,5 @@
   language: python
   language_version: python3
   pass_filenames: false
-  files: ^poetry\.lock$
+  files: ^(.*/)?poetry\.lock$
   args: ["-f", "requirements.txt", "-o", "requirements.txt"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,5 +5,5 @@
   language: python
   language_version: python3
   pass_filenames: false
-  files: ^poetry.lock$
+  files: ^poetry\.lock$
   args: ["-f", "requirements.txt", "-o", "requirements.txt"]


### PR DESCRIPTION
In regular expressions, the dot `.` is a metachar that matches every char. To match the literal dot it must be escaped `\.`.

Without the escape, that regex would match unintended filenames, such as `poetry-lock`, `poetry_lock`, `poetryblock`, `poetryclock` and other variations.