### PR TITLE
Enable Resolving PathDependencies

### DIFF
--- a/src/poetry_plugin_export/command.py
+++ b/src/poetry_plugin_export/command.py
@@ -51,6 +51,11 @@ class ExportCommand(GroupCommand):
         ),
         option("all-extras", None, "Include all sets of extra dependencies."),
         option("with-credentials", None, "Include credentials for extra indices."),
+        option(
+            "resolve-path-dependencies",
+            "P",
+            "Resolve path dependencies to package versions.",
+        ),
     ]
 
     @property
@@ -122,6 +127,7 @@ class ExportCommand(GroupCommand):
         exporter.with_hashes(not self.option("without-hashes"))
         exporter.with_credentials(self.option("with-credentials"))
         exporter.with_urls(not self.option("without-urls"))
+        exporter.resolve_path_dependencies(self.option("resolve-path-dependencies"))
         exporter.export(fmt, Path.cwd(), output or self.io)
 
         return 0

--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -74,6 +74,13 @@ class Exporter:
 
         return self
 
+    def resolve_path_dependencies(
+        self, resolve_path_dependencies: bool = False
+    ) -> Exporter:
+        self._resolve_path_dependencies = resolve_path_dependencies
+
+        return self
+
     def export(self, fmt: str, cwd: Path, output: IO | str) -> None:
         if not self.is_format_supported(fmt):
             raise ValueError(f"Invalid export format: {fmt}")
@@ -81,7 +88,11 @@ class Exporter:
         getattr(self, self.EXPORT_METHODS[fmt])(cwd, output)
 
     def _export_generic_txt(
-        self, cwd: Path, output: IO | str, with_extras: bool, allow_editable: bool
+        self,
+        cwd: Path,
+        output: IO | str,
+        with_extras: bool,
+        allow_editable: bool,
     ) -> None:
         from poetry.core.packages.utils.utils import path_to_url
 
@@ -117,8 +128,8 @@ class Exporter:
                 continue
 
             requirement = dependency.to_pep_508(with_extras=False, resolved=True)
-            is_direct_local_reference = (
-                dependency.is_file() or dependency.is_directory()
+            is_direct_local_reference = dependency.is_file() or (
+                dependency.is_directory() and not self._resolve_path_dependencies
             )
             is_direct_remote_reference = dependency.is_vcs() or dependency.is_url()
 

--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -42,6 +42,7 @@ class Exporter:
         self._with_hashes = True
         self._with_credentials = False
         self._with_urls = True
+        self._resolve_path_dependencies = False
         self._extras: Collection[NormalizedName] = ()
         self._groups: Iterable[str] = [MAIN_GROUP]
 


### PR DESCRIPTION
This change adds a simple option to the export command to allow the exporting of path dependencies as their resolved version number.

This is to support a monorepo design where deployment to AWS requires a `requirements.txt` file in order to build Lambda Layers.