### PR TITLE
fix export of marker unions with extras (requires poetry-core >= 2.5.0)

### DIFF
--- a/src/poetry_plugin_export/walker.py
+++ b/src/poetry_plugin_export/walker.py
@@ -273,10 +273,18 @@ def get_project_dependency_packages2(
             continue
 
         marker = info.get_marker(groups)
-        if not marker.validate({"extra": extras}):
-            continue
+        try:
+            marker = marker.apply({"extra": extras})  # type: ignore[attr-defined]
+        except AttributeError:
+            # poetry-core <= 1.4.2
+            if not marker.validate({"extra": extras}):
+                continue
 
-        marker = marker.without_extras()
+            marker = marker.without_extras()
+
+        else:
+            if marker.is_empty():
+                continue
 
         if project_python_marker:
             marker = project_python_marker.intersect(marker)

--- a/tests/test_exporter_pylock_toml.py
+++ b/tests/test_exporter_pylock_toml.py
@@ -10,6 +10,7 @@ from packaging.utils import canonicalize_name
 from poetry.core.constraints.version import Version
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.package import Package
+from poetry.core.version.markers import BaseMarker
 from poetry.factory import Factory
 from poetry.packages import Locker as BaseLocker
 from poetry.repositories import Repository
@@ -974,7 +975,7 @@ extras = []
             {"main"},
             {"extra1"},
             'python_version >= "3.6" or extra == "extra1"',
-            'python_version >= "3.6"',
+            "*" if hasattr(BaseMarker, "apply") else 'python_version >= "3.6"',
         ),
         ({"main"}, {"extra1"}, 'python_version >= "3.6" and extra != "extra1"', ""),
     ],


### PR DESCRIPTION
Although, there is no released version of poetry-core > 2.4.1 at the moment, we still need this fix for downstream tests in the Poetry repo.