### PR TITLE
fix: write file exports with LF newlines

### DIFF
--- a/src/poetry_plugin_export/exporter.py
+++ b/src/poetry_plugin_export/exporter.py
@@ -102,7 +102,7 @@ class Exporter:
         if isinstance(output, IO):
             output.write(content)
         else:
-            with (cwd / output).open("w", encoding="utf-8") as txt:
+            with (cwd / output).open("w", encoding="utf-8", newline="\n") as txt:
                 txt.write(content)
 
     def _export_generic_txt(

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -157,6 +157,8 @@ def test_exporter_can_export_requirements_txt_with_standard_packages(
     exporter = Exporter(poetry, NullIO())
     exporter.export("requirements.txt", tmp_path, "requirements.txt")
 
+    assert b"\r\n" not in (tmp_path / "requirements.txt").read_bytes()
+
     with (tmp_path / "requirements.txt").open(encoding="utf-8") as f:
         content = f.read()
 


### PR DESCRIPTION
## Summary

Fixes #325 by writing file exports with explicit LF newlines instead of relying on the platform default text newline translation.

## Changes

- Pass `newline="\n"` when writing exported files to disk.
- Add a regression assertion that generated `requirements.txt` bytes do not contain CRLF line endings.
- Leave stdout/IO output unchanged.

## Verification

- `pytest tests/test_exporter.py::test_exporter_can_export_requirements_txt_with_standard_packages -q`
- `pytest -q`
  - 178 passed
- `ruff check src tests`
- `python -m py_compile src/poetry_plugin_export/*.py`
- `git diff --check`